### PR TITLE
Mycopolitan deploy v02

### DIFF
--- a/SECRET_CONFIG_dummy.json
+++ b/SECRET_CONFIG_dummy.json
@@ -1,13 +1,26 @@
 {
-    "network_settings" : {
+    "network_setup" : {
+        "debug"        : false,
         "ap_if_active" : false,
+        "ap_essid"     : "mycopython-ap",
         "sta_if_active": true,
-        "connections": [["dummy","dumbpassword"]],
-        
-    }
-    "database_server_settings" : {
-        "host"       : "127.0.0.1",
-        "public_key" : "xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-        "private_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "connections": [["xxxx","xxxxxxxx"]],
+    },
+    "time_manager" : {
+        "debug"      : false,
+        "host"       : "pool.ntp.org",
+        "port"       : 123,
+    },
+    "data_stream" : {
+        "debug"      : false,
+        "host"       : "ddd.ddd.ddd.ddd",
+        "port"       : 8080,
+        "public_key" : "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "private_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    },
+    "datalogger_app" : {
+        "debug"           : 0,
+        "sample_interval" : 10,
+        "tz_hour_shift"   : -5,
     }
 }

--- a/datalogger_app.py
+++ b/datalogger_app.py
@@ -115,14 +115,21 @@ while True:
               year=year, month=month, day=day, hour=hour, minute=minute, second=second)
         local_hour = (hour + tz_hour_shift) % 24
         d['local_hour']    = local_hour
-        print("The day of the week is {day_name} and the local hour is {local_hour:d}.".format(day_name=WEEKDAYS[weekday], local_hour = local_hour))
+        if DEBUG >= 1:
+            print("The day of the week is {day_name} and the local hour is {local_hour:d}.".format(day_name=WEEKDAYS[weekday], local_hour = local_hour))
         #acquire a humidity and temperature sample
         ht_sensor.get_data(d)  #adds fields 'humid', 'temp'
         #acquire CO2 concentration sample
         co2_sensor.get_data(d) #adds field 'co2_ppm'
-        #debug reporting
-        if DEBUG >= 1:
-            print("Data to be logged:",d)
+        #Minimal Rporting
+        tmp = "{local_hour:02d}:{minute:02d}:{second:02d} - Data to be logged:"
+        report_header = tmp.format(local_hour = local_hour,
+                            minute = minute,
+                            second = second,
+                           )
+        print(report_header)
+        for key, val in d.items():
+            print("\t%s: %s" % (key,val))
         #check to see if we are still connected
         # CONNECTED ------------------------------------------------------------
         current_connection_state = sta_if.isconnected()


### PR DESCRIPTION
Disabled the data caching functionality, which has not been fully debugged.

Improved debugging modes, set through`config['datalogger_app']['debug']`:
0 -> minimal reporting to REPL at setup and main loop; exceptions are displayed but bypassed
1 -> more verbose reporting; exceptions are logged to `datalogger_app.ERROR_LOG_FILENAME`
2 -> all of mode 1; exceptions are re-raised in the error handler which will abort the app and send traceback to REPL